### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/file-overflow.yml
+++ b/.github/workflows/file-overflow.yml
@@ -1,4 +1,6 @@
 name: File Overflow and Error Prevention
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/Shanmukhasrisai/CyberMobilePenTest/security/code-scanning/3](https://github.com/Shanmukhasrisai/CyberMobilePenTest/security/code-scanning/3)

To fix the problem, we must explicitly set repository token permissions to the least privilege required. This is accomplished by adding a `permissions:` block at the root of the workflow YAML—before the `jobs:` key—which applies to all jobs by default. For this workflow, only reading repository contents is needed and no other GitHub API resources appear to be accessed. Thus, use `permissions: contents: read` at the root level. 

Edit file `.github/workflows/file-overflow.yml` by inserting the following block after the `name:` and before the `on:` block:

```yaml
permissions:
  contents: read
```

No further changes or imports are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
